### PR TITLE
add installation of python-coveralls during travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - "3.6"
 install: 
   - pip install -r requirements.txt
+  - pip install python-coveralls
 script: 
   - nosetests --with-coverage --cover-package=bucketlist
 after_success:
-  coveralls
+  - coveralls


### PR DESCRIPTION
#### what does this pr do?
Adds installation of python-coveralls during travis build.
#### Description of task to be completed
Test coverage information should be gathered during the travis build and displayed in the coveralls badge.